### PR TITLE
Lightweight documentation update and alignment of "containerizable" FAF commodites

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath(".."))
+sys.path.insert(0, os.path.abspath("../src"))
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/demand/faf.rst
+++ b/docs/demand/faf.rst
@@ -1,0 +1,13 @@
+Demand
+======
+
+We use FAF to source all origin-destination demand for "containerizable"
+freight. The list of excluded commodity codes is detailed in
+:data:`ireiat.config.NON_CONTAINERIZABLE_COMMODITIES`.
+
+Currently, there are no configurable CLI options for the data pipeline.
+
+.. automodule:: ireiat.util.faf_constants
+    :members:
+
+.. autodata:: ireiat.config.NON_CONTAINERIZABLE_COMMODITIES

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,9 @@ Welcome to IREIAT's documentation!
    :maxdepth: 2
    :caption: Contents:
 
+   demand/faf
    network/highway_network
+
 
 We are actively working on it.
 

--- a/src/ireiat/config.py
+++ b/src/ireiat/config.py
@@ -14,25 +14,37 @@ METERS_PER_MILE = 1609.34
 LATLONG_CRS = "EPSG:4326"
 ALBERS_CRS = "EPSG:5070"
 
-
 # FAF-related parameters
 SUM_TONS_TOLERANCE = 1e-5
 FAF_TONS_TARGET_FIELD = "tons_2022"
+
+#: List of commodities that are not containerizable
 NON_CONTAINERIZABLE_COMMODITIES = [
     FAFCommodity.LIVE_ANIMALS_FISH,
+    FAFCommodity.CEREAL_GRAINS,
     FAFCommodity.OTHER_AG_PRODS,
-    FAFCommodity.MEAT_SEAFOOD,
-    FAFCommodity.CRUDE_PETROLEUM,
-    FAFCommodity.COAL,
+    FAFCommodity.ANIMAL_FEED,
+    FAFCommodity.BUILDING_STONE,
+    FAFCommodity.NATURAL_SANDS,
     FAFCommodity.GRAVEL,
+    FAFCommodity.NONMETALLIC_MINERALS,
+    FAFCommodity.METALLIC_ORES,
+    FAFCommodity.COAL,
+    FAFCommodity.CRUDE_PETROLEUM,
     FAFCommodity.GASOLINE,
+    FAFCommodity.FUEL_OILS,
     FAFCommodity.NATURAL_GAS_AND_OTHER_FOSSIL_PRODUCTS,
-    FAFCommodity.FURNITURE,
-    FAFCommodity.PHARMACEUTICALS,
-    FAFCommodity.MIXED_FREIGHT,
+    FAFCommodity.BASIC_CHEMICALS,
+    FAFCommodity.FERTILIZERS,
+    FAFCommodity.LOGS,
+    FAFCommodity.WOOD_PRODS,
+    FAFCommodity.NEWSPRINT_PAPER,
+    FAFCommodity.NONMETAL_MIN_PRODS,
+    FAFCommodity.BASE_METALS,
+    FAFCommodity.WASTE_SCRAP,
 ]
 
-# exclude some states, regions from the input data
+#: Exclude some states, regions from the input data
 EXCLUDED_FIPS_CODES_MAP = {
     "Alaska": "02",
     "Hawaii": "15",
@@ -42,7 +54,6 @@ EXCLUDED_FIPS_CODES_MAP = {
     "Guam": "66",
     "US Virgin Islands": "78",
 }
-
 
 # TAP-related parameters
 HIGHWAY_CAPACITY_TONS = (

--- a/src/ireiat/data_pipeline/assets/demand/faf5_tons.py
+++ b/src/ireiat/data_pipeline/assets/demand/faf5_tons.py
@@ -22,9 +22,7 @@ def faf5_truck_demand(
     context: dagster.AssetExecutionContext, faf5_demand_src: pd.DataFrame
 ) -> pd.DataFrame:
     """FAF5 containerizable demand using the truck mode. Currently, FAF containerizable demand
-    is limited by commodity. Placeholder filter but is
-    meant to demonstrate how we can limit raw FAF data to intermodal-specific transits.
-    TODO (NP) - Determine a more robust methodology to filter containerizable demand"""
+    is limited by commodity. Based on OW knowledge of containerizable commodities"""
 
     # filter for containerizable
     is_containerizable = ~faf5_demand_src["sctg2"].isin(NON_CONTAINERIZABLE_COMMODITIES)

--- a/src/ireiat/util/faf_constants.py
+++ b/src/ireiat/util/faf_constants.py
@@ -2,7 +2,9 @@ from enum import IntEnum, StrEnum
 
 
 class FAFMode(IntEnum):
-    """FAF transit mode. See https://www.bts.gov/sites/bts.dot.gov/files/2021-02/FAF5-User-Guide.pdf"""
+    """
+    FAF transit mode. See https://www.bts.gov/sites/bts.dot.gov/files/2021-02/FAF5-User-Guide.pdf
+    """
 
     TRUCK = 1
     RAIL = 2
@@ -15,7 +17,9 @@ class FAFMode(IntEnum):
 
 
 class FAFCommodity(StrEnum):
-    """FAF SCTG2 codes. See https://www.bts.gov/sites/bts.dot.gov/files/2021-02/FAF5-User-Guide.pdf"""
+    """
+    FAF SCTG2 codes. See https://www.bts.gov/sites/bts.dot.gov/files/2021-02/FAF5-User-Guide.pdf
+    """
 
     LIVE_ANIMALS_FISH = "01"
     CEREAL_GRAINS = "02"


### PR DESCRIPTION
Align "containerizable" commodities with Yuri's list.

Update Sphinx docs to provide a slightly more detailed example using `autodoc`.