### PR TITLE
FAF5 Demand by Mode

### DIFF
--- a/docs/demand/faf.rst
+++ b/docs/demand/faf.rst
@@ -13,7 +13,7 @@ These modes are:
 1. **Truck**: ``faf5_truck_demand``
 2. **Rail**: ``faf5_rail_demand``
 3. **Water**: ``faf5_water_demand``
-4. **Other & Unknown**: ``faf5_other_and_unknow_demand``
+4. **Other & Unknown**: ``faf5_other_and_unknown_demand``
 
 Each dataset represents the total tons of demand between origin-destination pairs for that specific mode of transportation.
 

--- a/docs/demand/faf.rst
+++ b/docs/demand/faf.rst
@@ -5,6 +5,18 @@ We use FAF to source all origin-destination demand for "containerizable"
 freight. The list of excluded commodity codes is detailed in
 :data:`ireiat.config.NON_CONTAINERIZABLE_COMMODITIES`.
 
+The FAF dataset is subset by filtering out non-containerizable commodities.
+Once the containerizable demand is isolated, we further divide the data by transportation
+mode to create separate demand datasets for each mode of transportation.
+These modes are:
+
+1. **Truck**: ``faf5_truck_demand``
+2. **Rail**: ``faf5_rail_demand``
+3. **Water**: ``faf5_water_demand``
+4. **Other & Unknown**: ``faf5_other_and_unknow_demand``
+
+Each dataset represents the total tons of demand between origin-destination pairs for that specific mode of transportation.
+
 Currently, there are no configurable CLI options for the data pipeline.
 
 .. automodule:: ireiat.util.faf_constants

--- a/src/ireiat/data_pipeline/assets/demand/faf5_to_county.py
+++ b/src/ireiat/data_pipeline/assets/demand/faf5_to_county.py
@@ -46,7 +46,7 @@ def faf_id_to_county_areas(
             )
         ]
 
-        faf_zone_to_county[row.faf_zone] = np.round(tol_adjusted_county_intersection, 2).to_dict()
+        faf_zone_to_county[row.FAF_Zone] = np.round(tol_adjusted_county_intersection, 2).to_dict()
 
     # compute a map that links faf_zone_ids to counties
     # compute a map that tabulates the percentage of a county's area that's covered by a FAF zone
@@ -85,7 +85,7 @@ def faf_id_to_county_areas(
     assert min(county_coverage_canonical.values()) == 1.0
 
     # ensure every faf zone is covered
-    assert (set(faf5_regions_src["faf_zone"]) - set(faf_zone_to_county_canonical.keys())) == set()
+    assert (set(faf5_regions_src["FAF_Zone"]) - set(faf_zone_to_county_canonical.keys())) == set()
 
     # we relied on the index of the county geographic data to identify each county row - but, for usage with census data,
     # we serialize using the (STATEFP, COUNTYFP) code

--- a/src/ireiat/data_pipeline/assets/demand/faf5_tons.py
+++ b/src/ireiat/data_pipeline/assets/demand/faf5_tons.py
@@ -27,7 +27,7 @@ def faf5_demand_by_mode(
     context: dagster.AssetExecutionContext, faf5_demand_src: pd.DataFrame
 ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     """
-    Multi-asset function to extract demand data for different transport modes (Truck, Rail, Water).
+    Multi-asset function to extract demand data for different transport modes (Truck, Rail, Water, Other/Unknown).
     Currently, FAF containerizable demand is limited by commodity.
     """
 

--- a/src/ireiat/data_pipeline/io_manager.py
+++ b/src/ireiat/data_pipeline/io_manager.py
@@ -125,6 +125,11 @@ def asset_spec_factory(spec: dagster.AssetSpec):
     )
     def _asset(context: dagster.AssetExecutionContext):
         result = read_or_attempt_download(spec.key, spec.metadata)
+
+        # TODO: Make adjustments downstream to expect lower case headers, then uncomment below:
+        # Convert all column names to lowercase to avoid case-sensitivity issues
+        # result = result.rename(columns=lambda x: x.lower())
+
         publish_metadata(context, result)
         return result
 

--- a/src/ireiat/data_pipeline/metadata.py
+++ b/src/ireiat/data_pipeline/metadata.py
@@ -4,12 +4,22 @@ import pandas as pd
 
 
 def publish_metadata(
-    context: dagster.AssetExecutionContext, pdf: pd.DataFrame | geopandas.GeoDataFrame
+    context: dagster.AssetExecutionContext,
+    pdf: pd.DataFrame | geopandas.GeoDataFrame,
+    output_name: str = None,
 ) -> None:
     """Publishes metadata for pandas dataframes given a dagster execution context.
     Note excludes any column named "geometry" since these GIS data make reading tabular data
     difficult."""
     temp_df = pdf[[c for c in pdf.columns if c != "geometry"]]
-    context.add_output_metadata(
-        {"rows": len(temp_df), "preview": dagster.MetadataValue.md(temp_df.head().to_markdown())}
-    )
+
+    metadata = {
+        "rows": len(temp_df),
+        "preview": dagster.MetadataValue.md(temp_df.head().to_markdown()),
+    }
+
+    # If output_name is provided, use it; otherwise, log metadata without it
+    if output_name:
+        context.add_output_metadata(metadata, output_name=output_name)
+    else:
+        context.add_output_metadata(metadata)

--- a/src/ireiat/util/faf_constants.py
+++ b/src/ireiat/util/faf_constants.py
@@ -16,6 +16,17 @@ class FAFMode(IntEnum):
     NO_DOMESTIC_MODE = 8
 
 
+class FAFDemandByMode(StrEnum):
+    """
+    Enum representing different freight demand modes in the FAF dataset.
+    """
+
+    TRUCK = "faf_truck_demand"
+    RAIL = "faf_rail_demand"
+    WATER = "faf_water_demand"
+    OTHER_AND_UNKNOWN = "faf_other_and_unknown_demand"
+
+
 class FAFCommodity(StrEnum):
     """
     FAF SCTG2 codes. See https://www.bts.gov/sites/bts.dot.gov/files/2021-02/FAF5-User-Guide.pdf

--- a/src/ireiat/util/faf_constants.py
+++ b/src/ireiat/util/faf_constants.py
@@ -21,10 +21,10 @@ class FAFDemandByMode(StrEnum):
     Enum representing different freight demand modes in the FAF dataset.
     """
 
-    TRUCK = "faf_truck_demand"
-    RAIL = "faf_rail_demand"
-    WATER = "faf_water_demand"
-    OTHER_AND_UNKNOWN = "faf_other_and_unknown_demand"
+    TRUCK = "faf5_truck_demand"
+    RAIL = "faf5_rail_demand"
+    WATER = "faf5_water_demand"
+    OTHER_AND_UNKNOWN = "faf5_other_and_unknown_demand"
 
 
 class FAFCommodity(StrEnum):


### PR DESCRIPTION
Trello: https://trello.com/c/bJSkYqAi/41-create-a-multiasset-that-spits-out-faf-target-tons-by-mode-grouped-by-origin-and-destination-should-be-four-output-assets